### PR TITLE
Corrected page_nav to properly highlight navigation

### DIFF
--- a/assets/admin/boltbb.twig
+++ b/assets/admin/boltbb.twig
@@ -2,7 +2,7 @@
 
 {% extends "_base/_page-nav.twig" %}
 
-{% block page_nav 'Extensions' %}
+{% block page_nav 'Settings/ExtendBolt' %}
 
 {% block page_title %}
 {{ __('BoltBB') }}{% if boltbb %} — {{ boltbb.title }}{% endif %}


### PR DESCRIPTION
Just a minor change to fix "Extras" not being highlighted as active in the main navigation when using the BoltBB extension.