### PR TITLE
assets not working in subfolder installs

### DIFF
--- a/src/Controller/Backend.php
+++ b/src/Controller/Backend.php
@@ -80,10 +80,10 @@ class Backend implements ControllerProviderInterface
     {
         /** @var BoltBBExtension $extension */
         $extension = $app['extensions']->get('Bolt/BoltBB');
-        $dir = $extension->getWebDirectory()->getPath();
+        $dir = $app['resources']->urlPrefix . "/" . $extension->getWebDirectory()->getPath();
 
         // Add our JS & CSS
-        $js = (new JavaScript('/' . $dir . '/js/boltbb.admin.js'))->setZone(Zone::BACKEND)->setPriority(20)->setLate(true);
+        $js = (new JavaScript($dir . '/js/boltbb.admin.js'))->setZone(Zone::BACKEND)->setPriority(20)->setLate(true);
         $app['asset.queue.file']->add($js);
     }
 


### PR DESCRIPTION
Im using this extension (and others like it) as a sample on how to do the more complex stuff when coding bolt extensions. Thanks for that!

In my extension, i found out that loading assets with paths as above will not work when bolt is installed in a subfolder. The `$app['resources']->urlPrefix` seems to take care of that. If there is a better way, feel free to point me in the right direction.